### PR TITLE
Bump to v0.1.4

### DIFF
--- a/Casks/cartero.rb
+++ b/Casks/cartero.rb
@@ -1,22 +1,22 @@
 cask "cartero" do
-  arch arm: "arm64", intel: "amd64"
+  arch arm: "arm64", intel: "x64"
 
-  version "0.1.3"
-  sha256 arm:   "c74386a05f3c742fd1a4b699493bfdc79043f1887b28e8e79425cce05c7beff6",
-         intel: "45de50c4e9b35153759ca0c1a4516970e677fe64a20d080092e8397bd02212e4"
-  
+  version "0.1.4"
+  sha256 arm:   "b9f5f80d9d6381947139c697bb5a8f747a1d5c1fddaaf5101c3f23f28749a401",
+         intel: "8346b4faf0d54ee7f3074b79c411ac100d75d12054edb64505f8fd09b2073025"
+
   url "https://github.com/danirod/cartero/releases/download/v#{version}/Cartero-#{version}-macOS-#{arch}.dmg"
   name "Cartero"
   desc "Make HTTP requests and test APIs"
   homepage "https://cartero.danirod.es"
-  
+
   livecheck do
     url :url
     strategy :github_latest
   end
-  
+
   auto_updates true
-  
+
   depends_on macos: ">= :mojave"
 
   app "Cartero.app"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,3 @@ Now you can install any version hosted as cask with
 ```bash
 brew install --cask cartero
 ```
-
-> [!WARNING] 
-> **This version are currently not notarized or signed.**
-> On first run on macOS, you'll need to right click the app and use the Open menu.
-> [Visit Apple Support](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac).
-> If you don't trust these binary distributions, you can always build from sources.


### PR DESCRIPTION
Due to some changes in the release process, the Intel version now uses a different suffix for the file name, so I am updating the `arch` section of the formula as well.