### PR TITLE
Revert "cartero: Update to version 0.2.2"

### DIFF
--- a/Casks/cartero.rb
+++ b/Casks/cartero.rb
@@ -1,9 +1,9 @@
 cask "cartero" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.2.2"
-  sha256 arm:   "fae6e3f90b85be2ef83206bca381d0f885f2b862340d7784ff3084ee407d0726",
-         intel: "a61c87828d1786b928ee0148a3a2d2b188c8cc9202d4745f475e437452a4b45f"
+  version "0.2.1"
+  sha256 arm:   "13200b4569e9e953436c46f6b4015dbee382b20b4d944d26d831a42df6188f79",
+         intel: "2ea892d30c66a0ef5e0d190b048ca91c3a5b1abce9773ed1bc926bbe57f736ce"
 
   url "https://github.com/danirod/cartero/releases/download/v#{version}/Cartero-#{version}-macOS-#{arch}.dmg",
       verified: "github.com/danirod/cartero/"


### PR DESCRIPTION
Reverts SoloAntonio/homebrew-cartero#99 for testing auto-bump.yml