### PR TITLE
 Remove unnecessary brew update from auto-bump workflow

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           echo "Using tap: ${{ env.TAP_NAME }} (${{ env.TAP_URL }})"
           brew tap ${{ env.TAP_NAME }} ${{ env.TAP_URL }}
-          brew update
           brew developer on
 
       - name: Authenticate GitHub CLI


### PR DESCRIPTION
Remove unecessary comand for this action. The brew update command was removed from the .github/workflows/auto-bump.yml file to improve workflow performance. This command is not required as brew tap already ensures the necessary tap is available, and updating all formulae is unnecessary for this action. This change streamlines the workflow and reduces execution time.