### PR TITLE
cartero: Update cask format to use on_arm/on_intel

### DIFF
--- a/Casks/cartero.rb
+++ b/Casks/cartero.rb
@@ -1,12 +1,18 @@
 cask "cartero" do
-  arch arm: "arm64", intel: "x64"
-
   version "0.2.2"
-  sha256 arm:   "fae6e3f90b85be2ef83206bca381d0f885f2b862340d7784ff3084ee407d0726",
-         intel: "a61c87828d1786b928ee0148a3a2d2b188c8cc9202d4745f475e437452a4b45f"
 
-  url "https://github.com/danirod/cartero/releases/download/v#{version}/Cartero-#{version}-macOS-#{arch}.dmg",
-      verified: "github.com/danirod/cartero/"
+  on_arm do
+    sha256 "fae6e3f90b85be2ef83206bca381d0f885f2b862340d7784ff3084ee407d0726"
+    url "https://github.com/danirod/cartero/releases/download/v#{version}/Cartero-#{version}-macOS-arm64.dmg",
+        verified: "github.com/danirod/cartero/"
+  end
+
+  on_intel do
+    sha256 "a61c87828d1786b928ee0148a3a2d2b188c8cc9202d4745f475e437452a4b45f"
+    url "https://github.com/danirod/cartero/releases/download/v#{version}/Cartero-#{version}-macOS-x64.dmg",
+        verified: "github.com/danirod/cartero/"
+  end
+
   name "Cartero"
   desc "Make HTTP requests and test APIs"
   homepage "https://cartero.danirod.es/"


### PR DESCRIPTION
Refactored the cask to use the newer `on_arm`/`on_intel` syntax instead of the `arch` conditional. This improves readability, aligns with current Homebrew Cask style guidelines, and helps prevent random errors in the `auto-bump.yml` GitHub Action.**

Let me know if you want a more technical or more casual tone!
