### PR TITLE
fix(ci): set HOMEBREW_GITHUB_API_TOKEN to avoid GitHub API rate limit

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Process casks
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}   
           CASKS: ${{ steps.find_casks.outputs.casks }}
         shell: bash
         run: |


### PR DESCRIPTION
Set HOMEBREW_GITHUB_API_TOKEN from GitHub Actions secrets to authenticate Homebrew and prevent rate limiting errors during livecheck and other API calls.

This increases the GitHub API rate limit from 60 to 5000 requests per hour.