### PR TITLE
Fix cask verification in auto-bump workflow

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -187,7 +187,7 @@ jobs:
             cp "$CASK_PATH" "$LOCAL_TAP_DIR/"
 
             echo "Installing updated cask to verify: $CASK_NAME from local tap"
-            if brew install --cask "$CASK_NAME"; then
+            if brew install --cask "$LOCAL_TAP/$CASK_NAME"; then
               git add "$CASK_PATH"
               git commit -m "$CASK_NAME: Update to version $LATEST_VERSION"
               git push -u origin "$BRANCH"


### PR DESCRIPTION
Update the workflow to create a local tap for verifying updated casks and use fully-qualified cask name to avoid ambiguity when the same cask exists in multiple taps.